### PR TITLE
Use volumes to store db data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,7 @@ services:
       - "MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}"
       - "MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}"
       - "MONGO_INITDB_DATABASE=${MONGO_INITDB_DATABASE}"
+    volumes:
+      - mongo-data:/data/db
+  volumes:
+    mongo-data:


### PR DESCRIPTION
Extending the functionality added in https://github.com/kubesail/deploy-node-app/pull/34, this PR makes use of volumes to store the database's persistent data outside the container running the mongo service.

More info on why using volumes is preferred can be found [here](https://docs.docker.com/storage/volumes/).

Additionally, when running MongoDB with Docker on Windows through a VirtualBox VM, due to issues with mounting directories and sharing between the host machine and Docker containers [*], this workaround is detrimental for this metamodule to work properly. Otherwise, the database fails to read/write any data, when using bind mounting.

[*] There's a reference about this specific issue in the description of the mongo image [on DockerHub](https://hub.docker.com/_/mongo).
(You can see it by going to `Caveats -> Where to Store Data`)